### PR TITLE
Sdmx im 3 1 0 constraint

### DIFF
--- a/schemas/SDMXMessage.xsd
+++ b/schemas/SDMXMessage.xsd
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright SDMX 2021 - http://www.sdmx.org -->
-<xs:schema targetNamespace="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message"
-		xmlns="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message"
-		xmlns:xs="http://www.w3.org/2001/XMLSchema"
-		xmlns:message="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message"
-		xmlns:footer="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message/footer"
-		xmlns:common="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common"
-		xmlns:structure="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure"
-		xmlns:registry="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/registry"
-		xmlns:dsd="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/data/structurespecific"
-		xmlns:metadata="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/metadata/generic"
-		elementFormDefault="qualified">
+<xs:schema targetNamespace="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message" xmlns="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:message="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message" xmlns:footer="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message/footer" xmlns:common="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common" xmlns:structure="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure" xmlns:registry="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/registry" xmlns:dsd="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/data/structurespecific" xmlns:metadata="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/metadata/generic" elementFormDefault="qualified">
 	<xs:import namespace="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message/footer" schemaLocation="SDMXMessageFooter.xsd"/>
 	<xs:import namespace="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common" schemaLocation="SDMXCommon.xsd"/>
 	<xs:import namespace="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure" schemaLocation="SDMXStructure.xsd"/>

--- a/schemas/SDMXMessage.xsd
+++ b/schemas/SDMXMessage.xsd
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright SDMX 2021 - http://www.sdmx.org -->
-<xs:schema xmlns="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message" xmlns:message="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message" targetNamespace="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message" xmlns:footer="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message/footer" xmlns:common="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common" xmlns:structure="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure" xmlns:registry="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/registry" xmlns:dsd="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/data/structurespecific" xmlns:metadata="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/metadata/generic" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xml="http://www.w3.org/XML/1998/namespace" elementFormDefault="qualified">
+<xs:schema targetNamespace="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message"
+		xmlns="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message"
+		xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		xmlns:message="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message"
+		xmlns:footer="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message/footer"
+		xmlns:common="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common"
+		xmlns:structure="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure"
+		xmlns:registry="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/registry"
+		xmlns:dsd="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/data/structurespecific"
+		xmlns:metadata="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/metadata/generic"
+		elementFormDefault="qualified">
 	<xs:import namespace="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message/footer" schemaLocation="SDMXMessageFooter.xsd"/>
 	<xs:import namespace="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common" schemaLocation="SDMXCommon.xsd"/>
 	<xs:import namespace="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure" schemaLocation="SDMXStructure.xsd"/>

--- a/schemas/SDMXMessageFooter.xsd
+++ b/schemas/SDMXMessageFooter.xsd
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright SDMX 2021 - http://www.sdmx.org -->
-<xs:schema targetNamespace="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message/footer"
-		xmlns="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message/footer"
-		xmlns:xs="http://www.w3.org/2001/XMLSchema"
-		xmlns:common="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common"
-		elementFormDefault="qualified">
+<xs:schema targetNamespace="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message/footer" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message/footer" xmlns:common="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common" elementFormDefault="qualified">
 	<xs:import namespace="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common" schemaLocation="SDMXCommon.xsd"/>
 	<xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
 	

--- a/schemas/SDMXMessageFooter.xsd
+++ b/schemas/SDMXMessageFooter.xsd
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright SDMX 2021 - http://www.sdmx.org -->
-<xs:schema targetNamespace="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message/footer" xmlns="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message/footer" xmlns:common="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xml="http://www.w3.org/XML/1998/namespace" elementFormDefault="qualified">
+<xs:schema targetNamespace="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message/footer"
+		xmlns="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message/footer"
+		xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		xmlns:common="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common"
+		elementFormDefault="qualified">
 	<xs:import namespace="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common" schemaLocation="SDMXCommon.xsd"/>
 	<xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
 	

--- a/schemas/SDMXRegistryRegistration.xsd
+++ b/schemas/SDMXRegistryRegistration.xsd
@@ -125,11 +125,6 @@
 						<xs:documentation>CubeRegion is used to provide sets of include or excluded values for dimensions when querying for data.</xs:documentation>
 					</xs:annotation>
 				</xs:element>
-				<xs:element name="MetadataTargetRegion" type="structure:MetadataTargetRegionType">
-					<xs:annotation>
-						<xs:documentation>MetadataTargetRegion is used to provide sets of included or excluded values for identifier components when querying for metadata.</xs:documentation>
-					</xs:annotation>
-				</xs:element>
 			</xs:choice>
 		</xs:sequence>
 		<xs:attribute name="returnConstraints" type="xs:boolean" default="false">

--- a/schemas/SDMXStructure.xsd
+++ b/schemas/SDMXStructure.xsd
@@ -46,6 +46,17 @@
 					<xs:field xpath="@version"/>
 				</xs:unique>
 			</xs:element>
+			<xs:element name="AvailabilityConstraints" type="AvailabilityConstraintsType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>AvailabilityConstraints contains a collection of availability constraints. The constraints may be detailed in full, or referenced from an external structure document or registry service.</xs:documentation>
+				</xs:annotation>
+				<xs:unique name="UniqueAvailabilityConstraint">
+					<xs:selector xpath="structure:AvailabilityConstraint"/>
+					<xs:field xpath="@id"/>
+					<xs:field xpath="@agencyID"/>
+					<xs:field xpath="@version"/>
+				</xs:unique>
+			</xs:element>
 			<xs:element name="Categorisations" type="CategorisationsType" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Categorisations contains a collection of structural object categorisations. This container may contain categorisations for many types of objects. The categorisations may be detailed in full, or referenced from an external structure document or registry service.</xs:documentation>
@@ -123,34 +134,12 @@
 					<xs:field xpath="@version"/>
 				</xs:unique>
 			</xs:element>
-			<xs:element name="DimensionConstraints" type="DimensionConstraintsType" minOccurs="0">
-				<xs:annotation>
-					<xs:documentation>Constraints contains a collection of dimension constraints. The constraints may be detailed in full, or referenced from an external structure document or registry service.</xs:documentation>
-				</xs:annotation>
-				<xs:unique name="UniqueDimensionConstraint">
-					<xs:selector xpath="structure:DimensionConstraint"/>
-					<xs:field xpath="@id"/>
-					<xs:field xpath="@agencyID"/>
-					<xs:field xpath="@version"/>
-				</xs:unique>
-			</xs:element>
 			<xs:element name="DataConstraints" type="DataConstraintsType" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>DataConstraints contains a collection of data constraints. The constraints may be detailed in full, or referenced from an external structure document or registry service.</xs:documentation>
 				</xs:annotation>
 				<xs:unique name="UniqueDataConstraint">
 					<xs:selector xpath="structure:DataConstraint"/>
-					<xs:field xpath="@id"/>
-					<xs:field xpath="@agencyID"/>
-					<xs:field xpath="@version"/>
-				</xs:unique>
-			</xs:element>
-			<xs:element name="AvailabilityConstraints" type="AvailabilityConstraintsType" minOccurs="0">
-				<xs:annotation>
-					<xs:documentation>AvailabilityConstraints contains a collection of availability constraints. The constraints may be detailed in full, or referenced from an external structure document or registry service.</xs:documentation>
-				</xs:annotation>
-				<xs:unique name="UniqueAvailabilityConstraint">
-					<xs:selector xpath="structure:AvailabilityConstraint"/>
 					<xs:field xpath="@id"/>
 					<xs:field xpath="@agencyID"/>
 					<xs:field xpath="@version"/>
@@ -200,6 +189,17 @@
 					<xs:field xpath="@version"/>
 				</xs:unique>
 			</xs:element>
+			<xs:element name="DimensionConstraints" type="DimensionConstraintsType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Constraints contains a collection of dimension constraints. The constraints may be detailed in full, or referenced from an external structure document or registry service.</xs:documentation>
+				</xs:annotation>
+				<xs:unique name="UniqueDimensionConstraint">
+					<xs:selector xpath="structure:DimensionConstraint"/>
+					<xs:field xpath="@id"/>
+					<xs:field xpath="@agencyID"/>
+					<xs:field xpath="@version"/>
+				</xs:unique>
+			</xs:element>
 			<xs:element name="GeographicCodelists" type="GeographicCodelistsType" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>GeographicCodelists contains a collection of geographi codelist descriptions. The codelists may be detailed in full, or referenced from an external structure document or registry service.</xs:documentation>
@@ -239,17 +239,6 @@
 				</xs:annotation>
 				<xs:unique name="UniqueHierarchyAssociation">
 					<xs:selector xpath="structure:HierarchyAssociation"/>
-					<xs:field xpath="@id"/>
-					<xs:field xpath="@agencyID"/>
-					<xs:field xpath="@version"/>
-				</xs:unique>
-			</xs:element>
-			<xs:element name="MetadataConstraints" type="MetadataConstraintsType" minOccurs="0">
-				<xs:annotation>
-					<xs:documentation>MetadataConstraints contains a collection of metadata constraint descriptions. The constraints may be detailed in full, or referenced from an external structure document or registry service.</xs:documentation>
-				</xs:annotation>
-				<xs:unique name="UniqueMetadataConstraint">
-					<xs:selector xpath="structure:MetadataConstraint"/>
 					<xs:field xpath="@id"/>
 					<xs:field xpath="@agencyID"/>
 					<xs:field xpath="@version"/>
@@ -759,22 +748,6 @@
 		</xs:sequence>
 	</xs:complexType>
 
-	<xs:complexType name="MetadataConstraintsType">
-		<xs:annotation>
-			<xs:documentation>MetadataConstraintsType describes the structure of the metadata constraints container. It contains one or more metadata constraint, which can be explicitly detailed or referenced from an external structure document or registry service. This container may contain both attachment and content constraints.</xs:documentation>
-		</xs:annotation>
-		<xs:sequence>
-			<xs:element name="MetadataConstraint" type="MetadataConstraintType" maxOccurs="unbounded">
-				<xs:annotation>
-					<xs:documentation>MetadataConstraint specifies a sub set of the definition of the allowable content of a metadata set.</xs:documentation>
-				</xs:annotation>
-				<xs:unique name="MetadataConstraint_MetadataTargetRegionInclusion">
-					<xs:selector xpath="structure:MetadataTargetRegion"/>
-					<xs:field xpath="@include"/>
-				</xs:unique>
-			</xs:element>
-		</xs:sequence>
-	</xs:complexType>
 
 	<xs:complexType name="MetadataflowsType">
 		<xs:annotation>

--- a/schemas/SDMXStructureBase.xsd
+++ b/schemas/SDMXStructureBase.xsd
@@ -195,16 +195,6 @@
 							<xs:documentation>Structure references the structure (data structure or metadata structure definition) which the structure usage is based upon. Implementations will have to refine the type to use a concrete structure reference (i.e. either a data structure or metadata structure definition reference).</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="DimensionConstraint" type="common:DimensionConstraintReferenceType" minOccurs="0">
-						<xs:annotation>
-							<xs:documentation>DimensionConstraint provides a reference to the dimension constraint which defines the dimensions being used by this flow.</xs:documentation>
-						</xs:annotation>
-					</xs:element>
-					<xs:element name="DataConstraints" type="common:DataConstraintAttachmentType" minOccurs="0">
-						<xs:annotation>
-							<xs:documentation>DataConstraints provides a list of references to the data constraints, which define the allowed data content for this flow.</xs:documentation>
-						</xs:annotation>
-					</xs:element>
 				</xs:sequence>
 			</xs:extension>
 		</xs:complexContent>

--- a/schemas/SDMXStructureConstraint.xsd
+++ b/schemas/SDMXStructureConstraint.xsd
@@ -323,7 +323,7 @@
 		</xs:annotation>
 		<xs:complexContent>
 			<xs:restriction base="MemberSelectionType">
-				<xs:choice>
+				<xs:choice minOccurs="0">
 					<xs:element name="Value" type="CubeKeyValueType" maxOccurs="unbounded"/>
 					<xs:element name="TimeRange" type="TimeRangeValueType"/>
 				</xs:choice>

--- a/schemas/SDMXStructureConstraint.xsd
+++ b/schemas/SDMXStructureConstraint.xsd
@@ -10,9 +10,9 @@
 		<xs:documentation>The constraint structure module defines the structure of data and metadata constraint constructs.</xs:documentation>
 	</xs:annotation>
 
-	<xs:complexType name="ConstraintBaseType" abstract="true">
+	<xs:complexType name="ConstraintType" abstract="true">
 		<xs:annotation>
-			<xs:documentation>ConstraintBaseType is an abstract base type that forms the basis of the main abstract ConstraintType. It requires that a name be provided.</xs:documentation>
+			<xs:documentation>ConstraintType is an abstract base type that forms the basis of a Data Constraint and Dimension Constraint</xs:documentation>
 		</xs:annotation>
 		<xs:complexContent>
 			<xs:restriction base="common:MaintainableType">
@@ -23,28 +23,6 @@
 					<xs:element ref="common:Description" minOccurs="0" maxOccurs="unbounded"/>
 				</xs:sequence>
 			</xs:restriction>
-		</xs:complexContent>
-	</xs:complexType>
-
-	<xs:complexType name="ConstraintType" abstract="true">
-		<xs:annotation>
-			<xs:documentation>ConstraintType is an abstract base type that specific types of constraints (data and metadata) restrict and extend to describe their details. These constraint types both define a constraint attachment and a release calendar.</xs:documentation>
-		</xs:annotation>
-		<xs:complexContent>
-			<xs:extension base="ConstraintBaseType">
-				<xs:sequence>
-					<xs:element name="ConstraintAttachment" type="AvailabilityConstraintAttachmentType" minOccurs="0">
-						<xs:annotation>
-							<xs:documentation>ConstraintAttachment describes the collection of constrainable artefacts that the constraint is attached to.</xs:documentation>
-						</xs:annotation>
-					</xs:element>
-					<xs:element name="ReleaseCalendar" type="ReleaseCalendarType" minOccurs="0">
-						<xs:annotation>
-							<xs:documentation>ReleaseCalendar defines dates on which the constrained data is to be made available.</xs:documentation>
-						</xs:annotation>
-					</xs:element>
-				</xs:sequence>
-			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
 
@@ -59,7 +37,6 @@
 					<xs:element ref="common:Link" minOccurs="0" maxOccurs="unbounded"/>
 					<xs:element ref="common:Name" maxOccurs="unbounded"/>
 					<xs:element ref="common:Description" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="ReleaseCalendar" type="ReleaseCalendarType" minOccurs="0"/>
 				</xs:sequence>
 				<xs:attribute name="urn" type="common:DataConstraintUrnType" use="optional"/>
 			</xs:restriction>
@@ -112,7 +89,7 @@
 		<xs:complexContent>
 			<xs:extension base="DimensionConstraintBaseType">
 				<xs:sequence>
-					<xs:element name="Dimensions" type="DimensionConstraintDimensionsType">
+					<xs:element name="Dimensions" type="DimensionConstraintDimensionsType" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>Dimensions defines dimensions usable in the context of the constrained data flow.</xs:documentation>
 						</xs:annotation>
@@ -128,124 +105,41 @@
 		</xs:annotation>
 		<xs:choice>
 			<xs:sequence>
-				<xs:element name="Dimension" type="common:DimensionReferenceType" maxOccurs="unbounded">
+				<xs:element name="Dimension" type="common:SingleNCNameIDType" maxOccurs="unbounded">
 					<xs:annotation>
 						<xs:documentation>This is used to reference dimensions in the data structure definition.</xs:documentation>
-					</xs:annotation>
-				</xs:element>
-				<xs:element name="TimeDimension" type="common:TimeDimensionReferenceType" minOccurs="0">
-					<xs:annotation>
-						<xs:documentation>This is used to reference the time dimension in the data structure definition.</xs:documentation>
-					</xs:annotation>
-				</xs:element>
-			</xs:sequence>
-			<xs:sequence>
-				<xs:element name="TimeDimension" type="common:TimeDimensionReferenceType">
-					<xs:annotation>
-						<xs:documentation>This is used to reference the time dimension in the data structure definition.</xs:documentation>
 					</xs:annotation>
 				</xs:element>
 			</xs:sequence>
 		</xs:choice>
 	</xs:complexType>
 
-	<xs:complexType name="AvailabilityConstraintBaseType" abstract="true">
-		<xs:annotation>
-			<xs:documentation>AvailabilityConstraintBaseType is an abstract base refinement of ConstraintType. The constraint attachment is restricted to artefacts related to data.</xs:documentation>
-		</xs:annotation>
-		<xs:complexContent>
-			<xs:restriction base="ConstraintType">
-				<xs:sequence>
-					<xs:element ref="common:Annotations" minOccurs="0"/>
-					<xs:element ref="common:Link" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element ref="common:Name" maxOccurs="unbounded"/>
-					<xs:element ref="common:Description" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="ConstraintAttachment" type="AvailabilityConstraintAttachmentType" minOccurs="0"/>
-				</xs:sequence>
-				<xs:attribute name="urn" type="common:AvailabilityConstraintUrnType" use="optional"/>
-			</xs:restriction>
-		</xs:complexContent>
-	</xs:complexType>
 
 	<xs:complexType name="AvailabilityConstraintType">
 		<xs:annotation>
 			<xs:documentation>AvailabilityConstraintType defines the structure of an availability constraint. This type of constraint contains the actual data currently present for the referenced object and is used to express data availability either by listing the available sets of keys (DataKeySet) or a set of component values (CubeRegion), e.g., in a data source. Availability constraints should not be (semantically) versioned.</xs:documentation>
 		</xs:annotation>
 		<xs:complexContent>
-			<xs:extension base="AvailabilityConstraintBaseType">
+			<xs:extension base="common:AnnotableType">
 				<xs:sequence>
-					<xs:element name="DataKeySet" type="DataKeySetType" minOccurs="0" maxOccurs="unbounded">
+					<xs:element name="ConstraintAttachment" type="AvailabilityConstraintAttachmentType" minOccurs="1" maxOccurs="1">
 						<xs:annotation>
-							<xs:documentation>DataKeySet defines a full, distinct set of dimension values and the attribute values associated with the key.</xs:documentation>
+							<xs:documentation>ConstraintAttachment describes the Constrainable structure the availability information is for</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="CubeRegion" type="CubeRegionType" minOccurs="0" maxOccurs="2">
+					<xs:element name="CubeRegion" type="CubeRegionType" minOccurs="1" maxOccurs="1">
 						<xs:annotation>
 							<xs:documentation>CubeRegion defines a slice of the data set (dimensions and attribute values) for the constrained artefact. A set of included or excluded regions can be described.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 				</xs:sequence>
+				<xs:attribute name="seriesCount" type="xs:int" use="optional"/>
+				<xs:attribute name="obsCount" type="xs:int" use="optional"/>
 			</xs:extension>
 		</xs:complexContent>
+
 	</xs:complexType>
 
-	<xs:complexType name="MetadataConstraintBaseType" abstract="true">
-		<xs:annotation>
-			<xs:documentation>MetadataConstraintBaseType is an abstract base refinement of ConstraintType to define allowed metadata content. It excludes the constraint attachment.".</xs:documentation>
-		</xs:annotation>
-		<xs:complexContent>
-			<xs:restriction base="ConstraintType">
-				<xs:sequence>
-					<xs:element ref="common:Annotations" minOccurs="0"/>
-					<xs:element ref="common:Link" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element ref="common:Name" maxOccurs="unbounded"/>
-					<xs:element ref="common:Description" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="ReleaseCalendar" type="ReleaseCalendarType" minOccurs="0"/>
-				</xs:sequence>
-				<xs:attribute name="urn" type="common:MetadataConstraintUrnType" use="optional"/>
-			</xs:restriction>
-		</xs:complexContent>
-	</xs:complexType>
-
-	<xs:complexType name="MetadataConstraintType">
-		<xs:annotation>
-			<xs:documentation>MetadataConstraintType defines the structure of a metadata constraint. A metadata constraint can specify allowed attribute values for metadata described by the constrained artefact.</xs:documentation>
-		</xs:annotation>
-		<xs:complexContent>
-			<xs:extension base="MetadataConstraintBaseType">
-				<xs:sequence>
-					<xs:element name="MetadataTargetRegion" type="MetadataTargetRegionType" minOccurs="0" maxOccurs="2">
-						<xs:annotation>
-							<xs:documentation>MetadataTargetRegion describes the values allowed for metadata attributes.</xs:documentation>
-						</xs:annotation>
-					</xs:element>
-				</xs:sequence>
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-
-	<xs:complexType name="ReleaseCalendarType">
-		<xs:annotation>
-			<xs:documentation>ReleaseCalendarType describes information about the timing of releases of the constrained data. All of these values use the standard "P7D" - style format.</xs:documentation>
-		</xs:annotation>
-		<xs:sequence>
-			<xs:element name="Periodicity" type="xs:string">
-				<xs:annotation>
-					<xs:documentation>Periodicity is the period between releases of the data set.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-			<xs:element name="Offset" type="xs:string">
-				<xs:annotation>
-					<xs:documentation>Offset is the interval between January first and the first release of data within the year.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-			<xs:element name="Tolerance" type="xs:string">
-				<xs:annotation>
-					<xs:documentation>Tolerance is the period after which the release of data may be deemed late.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-		</xs:sequence>
-	</xs:complexType>
 
 	<xs:complexType name="DataKeySetType">
 		<xs:annotation>
@@ -270,54 +164,21 @@
 			<xs:documentation>AvailabilityConstraintAttachmentType describes a collection of references to data-related artefacts, for which availability is provided.</xs:documentation>
 		</xs:annotation>
 		<xs:choice>
-			<xs:element name="DataProvider" type="common:DataProviderReferenceType">
-				<xs:annotation>
-					<xs:documentation>DataProvider is reference to a data provider to which the constraint is attached. If this is used, then only the release calendar is relevant. The referenced is provided as a URN and/or a full set of reference fields.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-			<xs:element name="SimpleDataSource" type="xs:anyURI">
-				<xs:annotation>
-					<xs:documentation>SimpleDataSource describes a simple data source, which is a URL of a SDMX-ML data or metadata message.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-			<xs:choice>
-				<xs:sequence>
-					<xs:element name="DataStructure" type="common:DataStructureReferenceType">
-						<xs:annotation>
-							<xs:documentation>DataStructure is reference to a data structure definition to which the constraint is attached. The referenced is provided as a URN and/or a full set of reference fields. A constraint which is attached to more than one data structure must only express key sets and/or cube regions where the identifiers of the dimensions are common across all structures to which the constraint is attached.</xs:documentation>
-						</xs:annotation>
-					</xs:element>
-					<xs:element name="QueryableDataSource" type="common:QueryableDataSourceType" minOccurs="0">
-						<xs:annotation>
-							<xs:documentation>QueryableDataSource describes a queryable data source to which the constraint is attached.</xs:documentation>
-						</xs:annotation>
-					</xs:element>
-				</xs:sequence>
-				<xs:sequence>
-					<xs:element name="Dataflow" type="common:DataflowReferenceType">
-						<xs:annotation>
-							<xs:documentation>Dataflow is reference to a data flow to which the constraint is attached. The referenced is provided as a URN and/or a full set of reference fields. A constraint can be attached to more than one dataflow, and the dataflows do not necessarily have to be usages of the same data structure. However, a constraint which is attached to more than one data structure must only express key sets and/or cube regions where the identifiers of the dimensions are common across all structures to which the constraint is attached.</xs:documentation>
-						</xs:annotation>
-					</xs:element>
-					<xs:element name="QueryableDataSource" type="common:QueryableDataSourceType" minOccurs="0">
-						<xs:annotation>
-							<xs:documentation>QueryableDataSource describes a queryable data source to which the constraint is attached.</xs:documentation>
-						</xs:annotation>
-					</xs:element>
-				</xs:sequence>
-				<xs:sequence>
-					<xs:element name="ProvisionAgreement" type="common:ProvisionAgreementReferenceType">
-						<xs:annotation>
-							<xs:documentation>ProvisionAgreementReference is reference to a provision agreement to which the constraint is attached. The referenced is provided as a URN and/or a full set of reference fields. A constraint can be attached to more than one provision aggreement, and the provision agreements do not necessarily have to be references structure usages based on the same structure. However, a constraint which is attached to more than one provision agreement must only express key sets and/or cube/target regions where the identifier of the components are common across all structures to which the constraint is attached.</xs:documentation>
-						</xs:annotation>
-					</xs:element>
-					<xs:element name="QueryableDataSource" type="common:QueryableDataSourceType" minOccurs="0" maxOccurs="unbounded">
-						<xs:annotation>
-							<xs:documentation>QueryableDataSource describes a queryable data source to which the constraint is attached.</xs:documentation>
-						</xs:annotation>
-					</xs:element>
-				</xs:sequence>
-			</xs:choice>
+				<xs:element name="DataStructure" type="common:DataStructureReferenceType">
+					<xs:annotation>
+						<xs:documentation>DataStructure is reference to a data structure definition to which the constraint is attached. The referenced is provided as a URN and/or a full set of reference fields. A constraint which is attached to more than one data structure must only express key sets and/or cube regions where the identifiers of the dimensions are common across all structures to which the constraint is attached.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="Dataflow" type="common:DataflowReferenceType">
+					<xs:annotation>
+						<xs:documentation>Dataflow is reference to a data flow to which the constraint is attached. The referenced is provided as a URN and/or a full set of reference fields. A constraint can be attached to more than one dataflow, and the dataflows do not necessarily have to be usages of the same data structure. However, a constraint which is attached to more than one data structure must only express key sets and/or cube regions where the identifiers of the dimensions are common across all structures to which the constraint is attached.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="ProvisionAgreement" type="common:ProvisionAgreementReferenceType">
+					<xs:annotation>
+						<xs:documentation>ProvisionAgreementReference is reference to a provision agreement to which the constraint is attached. The referenced is provided as a URN and/or a full set of reference fields. A constraint can be attached to more than one provision aggreement, and the provision agreements do not necessarily have to be references structure usages based on the same structure. However, a constraint which is attached to more than one provision agreement must only express key sets and/or cube/target regions where the identifier of the components are common across all structures to which the constraint is attached.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
 		</xs:choice>
 	</xs:complexType>
 
@@ -447,7 +308,6 @@
 			<xs:restriction base="RegionType">
 				<xs:sequence>
 					<xs:element ref="common:Annotations" minOccurs="0"/>
-					<xs:element name="KeyValue" type="CubeRegionKeyType" minOccurs="0" maxOccurs="unbounded"/>
 					<xs:element name="Component" type="ComponentValueSetType" minOccurs="0" maxOccurs="unbounded"/>
 				</xs:sequence>
 				<xs:attribute name="validFrom" type="common:StandardTimePeriodType" use="prohibited"/>
@@ -456,22 +316,10 @@
 		</xs:complexContent>
 	</xs:complexType>
 
-	<xs:complexType name="MetadataTargetRegionType">
+	<xs:complexType name="ComponentValueSetType">
 		<xs:annotation>
-			<xs:documentation>MetadataTargetRegionType defines the structure of a metadata target region. A metadata target region must define the report structure and the metadata target from that structure on which the region is based. This type is based on the abstract RegionType and simply refines the key and attribute values to conform with what is applicable for target objects and metadata attributes, respectively. See the documentation of the base type for more details on how a region is defined.</xs:documentation>
-		</xs:annotation>
-		<xs:complexContent>
-			<xs:restriction base="RegionType">
-				<xs:sequence>
-					<xs:element name="Component" type="MetadataAttributeValueSetType" minOccurs="0" maxOccurs="unbounded"/>
-				</xs:sequence>
-			</xs:restriction>
-		</xs:complexContent>
-	</xs:complexType>
-
-	<xs:complexType name="CubeRegionKeyType">
-		<xs:annotation>
-			<xs:documentation>CubeRegionKeyType is a type for providing a set of values for a dimension for the purpose of defining a data cube region. A set of distinct value can be provided, or if this dimension is represented as time, and time range can be specified.</xs:documentation>
+			<xs:documentation>ComponentValueSetType is a type for providing a set of values for any Components (Dimension, Attribute, Measure) of a DSD or MSD for the purpose of defining a data cube region. 
+			                  A set of distinct value can be provided, or if this dimension is represented as time, and time range can be specified.</xs:documentation>
 		</xs:annotation>
 		<xs:complexContent>
 			<xs:restriction base="MemberSelectionType">
@@ -480,42 +328,12 @@
 					<xs:element name="TimeRange" type="TimeRangeValueType"/>
 				</xs:choice>
 				<xs:attribute name="id" type="common:SingleNCNameIDType" use="required"/>
-			</xs:restriction>
-		</xs:complexContent>
-	</xs:complexType>
-
-	<xs:complexType name="ComponentValueSetType">
-		<xs:annotation>
-			<xs:documentation>ComponentValueSetType defines the structure for providing values for a data attributes, measures, or metadata attributes. If no values are provided, the component is implied to include/excluded from the region in which it is defined, with no regard to the value of the component. Note that for metadata attributes which occur within other metadata attributes, a nested identifier can be provided. For example, a value of CONTACT.ADDRESS.STREET refers to the metadata attribute with the identifier STREET which exists in the ADDRESS metadata attribute in the CONTACT metadata attribute, which is defined at the root of the report structure.</xs:documentation>
-		</xs:annotation>
-		<xs:complexContent>
-			<xs:restriction base="MemberSelectionType">
-				<xs:choice minOccurs="0">
-					<xs:element name="Value" type="SimpleComponentValueType" maxOccurs="unbounded"/>
-					<xs:element name="TimeRange" type="TimeRangeValueType"/>
-				</xs:choice>
-				<xs:attribute name="id" type="common:NestedNCNameIDType" use="required"/>
 				<xs:attribute name="validFrom" type="common:StandardTimePeriodType" use="prohibited"/>
 				<xs:attribute name="validTo" type="common:StandardTimePeriodType" use="prohibited"/>
 			</xs:restriction>
 		</xs:complexContent>
 	</xs:complexType>
 
-	<xs:complexType name="MetadataAttributeValueSetType">
-		<xs:annotation>
-			<xs:documentation>MetadataAttributeValueSetType defines the structure for providing values for a metadata attribute. If no values are provided, the attribute is implied to include/excluded from the region in which it is defined, with no regard to the value of the metadata attribute.</xs:documentation>
-		</xs:annotation>
-		<xs:complexContent>
-			<xs:restriction base="MemberSelectionType">
-				<xs:choice minOccurs="0">
-					<xs:element name="Value" type="SimpleComponentValueType" maxOccurs="unbounded"/>
-					<xs:element name="TimeRange" type="TimeRangeValueType"/>
-				</xs:choice>
-				<xs:attribute name="validFrom" type="common:StandardTimePeriodType" use="prohibited"/>
-				<xs:attribute name="validTo" type="common:StandardTimePeriodType" use="prohibited"/>
-			</xs:restriction>
-		</xs:complexContent>
-	</xs:complexType>
 
 	<xs:complexType name="SimpleComponentValueType">
 		<xs:annotation>

--- a/schemas/SDMXStructureDataflow.xsd
+++ b/schemas/SDMXStructureDataflow.xsd
@@ -9,7 +9,7 @@
 		<xs:documentation>The data flow structure module defines the structure of data flow constructs.</xs:documentation>
 	</xs:annotation>
 
-	<xs:complexType name="DataflowType">
+	<xs:complexType name="DataflowBaseType">
 		<xs:annotation>
 			<xs:documentation>DataflowType describes the structure of a data flow. A data flow is defined as the structure of data that will provided for different reference periods. If this type is not defined externally, then a reference to a data structure must be provided.</xs:documentation>
 		</xs:annotation>
@@ -25,19 +25,31 @@
 							<xs:documentation>Structure provides a reference to the data structure definition that defines the structure of all data for this flow.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="DimensionConstraint" type="common:DimensionConstraintReferenceType" minOccurs="0">
-						<xs:annotation>
-							<xs:documentation>DimensionConstraint provides a reference to the dimension constraint that defines the dimensions being used by this flow.</xs:documentation>
-						</xs:annotation>
-					</xs:element>
+				</xs:sequence>
+				<xs:attribute name="urn" type="common:DataflowUrnType" use="optional"/>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	
+	<xs:complexType name="DataflowType">
+		<xs:annotation>
+			<xs:documentation>DataflowType describes the structure of a data flow. A data flow is defined as the structure of data that will provided for different reference periods. If this type is not defined externally, then a reference to a data structure must be provided.</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="DataflowBaseType">
+				<xs:sequence>
 					<xs:element name="DataConstraints" type="common:DataConstraintAttachmentType" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>DataConstraints provides a list of references to the data constraints that define the allowed data content for this flow.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
+					<xs:element name="DimensionConstraint" type="common:DimensionConstraintReferenceType" minOccurs="0" maxOccurs="1">
+						<xs:annotation>
+							<xs:documentation>DimensionConstraint provides a reference to the dimension constraint that defines the dimensions being used by this flow.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
 				</xs:sequence>
-				<xs:attribute name="urn" type="common:DataflowUrnType" use="optional"/>
-			</xs:restriction>
+			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
 

--- a/schemas/SDMXStructureMetadataStructure.xsd
+++ b/schemas/SDMXStructureMetadataStructure.xsd
@@ -36,7 +36,11 @@
 		<xs:complexContent>
 			<xs:extension base="MetadataStructureBaseType">
 				<xs:sequence>
-					<xs:element name="MetadataConstraints" type="common:MetadataConstraintAttachmentType" minOccurs="0"/>
+					<xs:element name="MetadataConstraints" type="common:DataConstraintAttachmentType" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>MetadataConstraints provides a list of references to the data constraints that are used to restrict allowable content using include and/or exclude rules on reported values.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
 				</xs:sequence>
 			</xs:extension>
 		</xs:complexContent>

--- a/schemas/SDMXStructureMetadataflow.xsd
+++ b/schemas/SDMXStructureMetadataflow.xsd
@@ -43,7 +43,11 @@
 							<xs:documentation>References identifiable structures to which the refernece metadata described by the referenced metadata structure should be restricted to. These references may include wildcards for parts of the reference.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="MetadataConstraints" type="common:MetadataConstraintAttachmentType" minOccurs="0"/>
+					<xs:element name="MetadataConstraints" type="common:DataConstraintAttachmentType" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>MetadataConstraints provides a list of references to the data constraints that are used to restrict allowable content using include and/or exclude rules on reported values.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
 				</xs:sequence>
 			</xs:extension>
 		</xs:complexContent>

--- a/schemas/SDMXStructureProvisionAgreement.xsd
+++ b/schemas/SDMXStructureProvisionAgreement.xsd
@@ -88,7 +88,7 @@
 							<xs:documentation>References identifiable structures to which the refernece metadata described by the metadata structure used by the metadaflow should be restricted to. These references may include wildcards for parts of the reference.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="MetadataConstraints" type="common:MetadataConstraintAttachmentType" minOccurs="0"/>
+					<xs:element name="MetadataConstraints" type="common:DataConstraintAttachmentType" minOccurs="0"/>
 				</xs:sequence>
 			</xs:extension>
 		</xs:complexContent>


### PR DESCRIPTION
Simplifications to the model
1. remove the Metadata Constraint - MSD, Metadataflow, and PA now use same constraint as DSD,Dataflow,PA
2. remove release calendar (does not make sense for dataflow to have more then 1, it is ambigous if it is restricting or reporting)
3. CubeRegion constraint, remove distinction between what is a Key (Dimension value) and what is a Component (every other component) - just keep Component.
4. Dimension Constraint - allow zero Dimension references to support stubs. Change reference type to IDType as it is an indirect reference through the dataflow (same reference type as Cube Region to a Component)
5. AvailabilityConstraint - extends annotable (no longer maintainable)
6. Ensure structure.xsd structures are in alphabetical order