### PR TITLE
docs: standardise README; fix heading; remove stale release-version line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Overview
-=========
+# Overview
+
 This repository is used for maintaining the SDMX-ML messages specifications.
 
 This includes:
@@ -10,6 +10,25 @@ This includes:
 
 To test the samples, copy the ‘samples’ and ‘schemas’ folders into the same local directory.
 
-The current release version is SDMX-ML 3.1
-
 The schemas are published to https://xml.sdmx.org
+
+## Repository Structure
+
+-   `docs/` — Markdown content pages for the SDMX-ML specification.
+-   `mkdocs.yml` — MkDocs configuration integrating this component into the
+    `sdmx-docs` site.
+
+## Version Branches
+
+Each release of this component is maintained on a dedicated branch following the
+pattern `X.Y.x` (e.g., `3.1.x`). The branch tracked by the
+[`sdmx-docs`](https://github.com/sdmx-twg/sdmx-docs) parent repository is
+declared in `.gitmodules` at the root of that repo. Switching the tracked branch
+in the parent repository is how a new version of this component is published on
+the documentation site.
+
+## Formatting Conventions
+
+For Markdown and MkDocs formatting conventions that apply to content in `docs/`,
+see the [`sdmx-docs` README](https://github.com/sdmx-twg/sdmx-docs#readme).
+


### PR DESCRIPTION
Convert Setext heading to ATX; remove "The current release version is SDMX-ML 3.1"; append Repository Structure, Version Branches, and Formatting Conventions sections to align with the shared template.